### PR TITLE
STOR-16309: Switch deprecated `ActiveSupport::PerThreadRegistry` to `thread_mattr_accessor` before Rails 7.1

### DIFF
--- a/lib/rails/observers/active_model/disabled_observers_registry.rb
+++ b/lib/rails/observers/active_model/disabled_observers_registry.rb
@@ -1,13 +1,11 @@
 module ActiveModel
   class DisabledObserversRegistry
-    extend ActiveSupport::PerThreadRegistry
+    # Preemptively getting ahead of this Rails 7.1 removal: 
+    # DEPRECATION WARNING: ActiveSupport::PerThreadRegistry is deprecated and will be removed in Rails 7.1. Use `Module#thread_mattr_accessor` instead.
+    thread_mattr_accessor :disabled_observers_per_class
+    thread_mattr_accessor :disabled_observers_stacks_per_class
 
-    attr_accessor :disabled_observers_per_class
-    attr_accessor :disabled_observers_stacks_per_class
-
-    def initialize
-      @disabled_observers_per_class         = {}
-      @disabled_observers_stacks_per_class  = {}
-    end
+    self.disabled_observers_per_class         = {}
+    self.disabled_observers_stacks_per_class  = {}
   end
 end


### PR DESCRIPTION
> DEPRECATION WARNING: ActiveSupport::PerThreadRegistry is deprecated and will be removed in Rails 7.1.
> Use `Module#thread_mattr_accessor` instead.
>  (called from extend at /Users/tyler.cook/.asdf_i386/installs/ruby/3.2.5/lib/ruby/gems/3.2.0/bundler/gems/rails-observers-2442abdaacb2/lib/rails/observers/active_model/disabled_observers_registry.rb:3)