### PR TITLE
EDGE-5604: Gem Compatibility: rails-observers

### DIFF
--- a/lib/rails/observers/active_model/disabled_observers_registry.rb
+++ b/lib/rails/observers/active_model/disabled_observers_registry.rb
@@ -2,7 +2,7 @@ module ActiveModel
   class DisabledObserversRegistry
     # Preemptively getting ahead of this Rails 7.1 removal: 
     # DEPRECATION WARNING: ActiveSupport::PerThreadRegistry is deprecated and will be removed in Rails 7.1. Use `Module#thread_mattr_accessor` instead.
-    thread_mattr_accessor :disabled_observers_per_class, default: {}
-    thread_mattr_accessor :disabled_observers_stacks_per_class, default: {}
+    thread_mattr_accessor :disabled_observers_per_class
+    thread_mattr_accessor :disabled_observers_stacks_per_class
   end
 end

--- a/lib/rails/observers/active_model/disabled_observers_registry.rb
+++ b/lib/rails/observers/active_model/disabled_observers_registry.rb
@@ -1,7 +1,5 @@
 module ActiveModel
   class DisabledObserversRegistry
-    # Preemptively getting ahead of this Rails 7.1 removal: 
-    # DEPRECATION WARNING: ActiveSupport::PerThreadRegistry is deprecated and will be removed in Rails 7.1. Use `Module#thread_mattr_accessor` instead.
     thread_mattr_accessor :disabled_observers_per_class
     thread_mattr_accessor :disabled_observers_stacks_per_class
   end

--- a/test/observer_array_test.rb
+++ b/test/observer_array_test.rb
@@ -168,6 +168,53 @@ class ObserverArrayTest < ActiveSupport::TestCase
     assert_observer_notified Widget, AuditTrail
   end
 
+  test "disabled_observers_per_class registry starts nil in a new thread with no shared default" do
+    value_in_thread = :unset
+    Thread.new do
+      value_in_thread = ActiveModel::DisabledObserversRegistry.disabled_observers_per_class
+    end.join
+    assert_nil value_in_thread
+  end
+
+  test "disabled_observers_stacks_per_class registry starts nil in a new thread with no shared default" do
+    value_in_thread = :unset
+    Thread.new do
+      value_in_thread = ActiveModel::DisabledObserversRegistry.disabled_observers_stacks_per_class
+    end.join
+    assert_nil value_in_thread
+  end
+
+  test "disabling an observer in one thread does not affect a concurrent thread" do
+    ready    = false
+    done     = false
+    mutex    = Mutex.new
+    cond     = ConditionVariable.new
+    thread_saw_disabled = nil
+
+    t = Thread.new do
+      mutex.synchronize { cond.wait(mutex) until ready }
+      thread_saw_disabled = Widget.observers.disabled_for?(AuditTrail.instance)
+      mutex.synchronize { done = true; cond.signal }
+    end
+
+    Widget.observers.disable :audit_trail
+    mutex.synchronize { ready = true; cond.signal }
+    mutex.synchronize { cond.wait(mutex) until done }
+    t.join
+
+    assert_equal false, thread_saw_disabled
+  end
+
+  test "transaction stack is not shared across threads" do
+    stack_in_thread = :unset
+    Widget.observers.disable :audit_trail do
+      Thread.new do
+        stack_in_thread = ActiveModel::DisabledObserversRegistry.disabled_observers_stacks_per_class
+      end.join
+    end
+    assert_nil stack_in_thread
+  end
+
   test "raises an appropriate error when a developer accidentally enables or disables the wrong class (i.e. Widget instead of WidgetObserver)" do
     assert_raise ArgumentError do
       ORM.observers.enable :widget


### PR DESCRIPTION
The rednovalabs/rails-observers fork (branch rails-7, version 0.2.0) uses thread_mattr_accessor :disabled_observers_per_class, default: {} in DisabledObserversRegistry. Rails 7.1 freezes these default values, so the first call to ActiveRecord::Base.observers.disable :all raises FrozenError: can't modify frozen Hash: {}. This blocks the entire test suite.